### PR TITLE
Added JACC Skeleton

### DIFF
--- a/src/com/bitmoji/Bitmoji.jacc
+++ b/src/com/bitmoji/Bitmoji.jacc
@@ -36,11 +36,127 @@
 //////////////////////////////////////////
 // Grammar Rules
 //////////////////////////////////////////
-program                 : START_PROGRAM
+program : START_PROGRAM stmnt_list END_PROGRAM
                         {
 
                         }
                         ;
+
+stmnt_list : stmnt_list statement
+			| statement
+			;
+
+statement : assignment 
+		  | while_statement
+		  | input
+		  | output
+		  | if_statement
+		  | function_call
+		  | function_def //Does this go in the program NT or does it go outside program NT?
+		  ;
+		  
+		  
+/*		  
+array_decl : ARRAY_DECL array_type ID //Dynamically-sized array.
+		  ;
+
+int_decl : INTEGER_DECL ID
+		  ;
+
+real_decl : REAL_DECL ID
+		  ;
+
+string_decl : STRING_DECL ID
+		  ;
+*/
+
+
+ref : ID LEFT_BRACKET expr RIGHT_BRACKET
+	| ID
+	;
+
+array_type : INTEGER_DECL
+		   | REAL_DECL
+		   | STRING_DECL
+		   ;
+		   
+expr : expr ADD term
+	 | expr SUBTRACT term
+	 | term
+	 | function_call
+	 ;
+	 
+term : term MULTIPLY factor
+	 | term DIVIDE factor
+	 | factor
+	 ;
+	 
+factor : factor EXPONENT exp
+	   | exp
+	   ;
+	   
+exp : LEFT_PARENTHESIS expr RIGHT_PARENTHESIS
+	| ref
+	| REAL_LITERAL
+	| INT_LITERAL
+	;
+	
+assignment : id ASSIGN expr
+		   ;
+
+while_statement : START_WHILE equality stmnt_list END_WHILE
+				;
+				
+input : INPUT ref
+	  ;
+
+output : OUTPUT expr
+	   | OUTPUT STRING_LITERAL
+	   ;
+
+conditional : if_statmenet
+			| if_statement elif_statement
+			| if_statement else_statement
+			| if_statement elif_statement else_statement
+
+if_statement : IF LEFT_PARENTHESIS equality RIGHT_PARENTHESIS START_THEN stmnt_list END_THEN
+			 ;
+
+elif_statement : ELIF LEFT_PARENTHESIS equality RIGHT_PARENTHESIS START_THEN stmnt_list END_THEN
+			   | ELIF LEFT_PARENTHESIS equality RIGHT_PARENTHESIS START_THEN stmnt_list END_THEN elif_statement
+			   ;
+
+else_statement : ELSE START_THEN stmnt_list END_THEN
+			   ;
+
+function_call : ID LEFT_PARENTHESIS ref_list RIGHT_PARENTHESIS
+			  ;
+			  
+ref_list : ref_list PARAMETER_COMMA ref
+		 | ref
+		 ;
+
+function_def : FUNCTION_DEF id LEFT_PARENTHESIS parameter_list RIGHT_PARENTHESIS START_FUNCTION_STATEMENTS stmnt_list RETURN LEFT_PARENTHESIS expr RIGHT_PARENTHESIS END_FUNCTION_STATEMENTS
+			 ;
+		   
+parameter_list : parameter_list PARAMETER_COMMA id
+			   | id
+			   ;
+			   
+
+equality : equality EQUALS relational
+		 | equality NOT_EQUALS relational
+		 | relational
+		 ;
+		 
+relational : relational GREATER_THAN expr
+		   | relational GREATER_THAN_OR_EQUAL expr
+		   | relational LESS_THAN expr
+		   | relational LESS_THAN_OR_EQUAL expr
+		   | expr
+		   ;
+
+
 %%
 
 //////////////////////////////////////////


### PR DESCRIPTION
Jacc grammar matches up-to-date BNF documentation.  No parse tree nodes are created yet.